### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "html"
+run = ""

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An HTML5 Tetris Game
  * [play the game](http://codeincomplete.com/projects/tetris/)
  * read a [blog article](http://codeincomplete.com/posts/2011/10/10/javascript_tetris/)
  * view the [source](https://github.com/jakesgordon/javascript-tetris)
+ [![Run on Repl.it](https://repl.it/badge/github/jakesgordon/javascript-tetris)](https://repl.it/github/jakesgordon/javascript-tetris)
 
 >> _*SUPPORTED BROWSERS*: Chrome, Firefox, Safari, Opera and IE9+_
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@enigma_dev/javascript-tetris).