### PR TITLE
Add Game Over message to canvas when player losesadd game over message to canvas when player loses

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
     //-------------------------------------------------------------------------
 
     function play() { hide('start'); reset();          playing = true;  }
-    function lose() { show('start'); setVisualScore(); playing = false; }
+    function lose() { show('start'); setVisualScore(); playing = false; invalidate(); drawGameOver(); }
 
     function setVisualScore(n)      { vscore = n || score; invalidateScore(); }
     function setScore(n)            { score = n; setVisualScore(n);  }
@@ -395,6 +395,8 @@
         ctx.strokeRect(0, 0, nx*dx - 1, ny*dy - 1); // court boundary
         invalid.court = false;
       }
+      if (!playing)
+        drawGameOver();
     }
 
     function drawNext() {
@@ -432,11 +434,19 @@
     }
 
     function drawBlock(ctx, x, y, color) {
-      ctx.fillStyle = color;
-      ctx.fillRect(x*dx, y*dy, dx, dy);
-      ctx.strokeRect(x*dx, y*dy, dx, dy)
-    }
+  ctx.fillStyle = color;
+  ctx.fillRect(x*dx, y*dy, dx, dy);
+  ctx.strokeRect(x*dx, y*dy, dx, dy)
+  }
 
+function drawGameOver() {
+  ctx.fillStyle = 'black';
+  ctx.fillRect(0, 0, canvas.width, canvas.height/2 - 20);
+  ctx.fillStyle = 'white';
+  ctx.font = 'bold 30px Arial';
+  ctx.textAlign = 'center';
+  ctx.fillText('GAME OVER', canvas.width/2, canvas.height/2);
+  }
     //-------------------------------------------------------------------------
     // FINALLY, lets run the game
     //-------------------------------------------------------------------------


### PR DESCRIPTION
What: This PR adds a "GAME OVER" message to the canvas when the player loses.

Why: When the game ends the screen just freezes with no message, 
which is confusing. This makes it clear the game is over.

Verified: I ran the game with python3 -m http.server 8080, played 
until I lost, and the "GAME OVER" text appeared on the canvas as expected.

Status: Ready for review.